### PR TITLE
MD: Recompute on changes in atom positions

### DIFF
--- a/asax/calculator.py
+++ b/asax/calculator.py
@@ -49,6 +49,10 @@ class Calculator(GetPropertiesMixin, ABC):
             self.update(atoms)
             return
 
+        if "positions" in changes:
+            self.results = self.compute_properties()
+            return
+
         # TODO: Detect changes in atom count/shape
         # => potential only requires re-initialization if this is the case
 


### PR DESCRIPTION
MD simulations cause changes in atomic positions and require a full recomputation of properties.